### PR TITLE
Support no_dereference option for link_to

### DIFF
--- a/mrblib/specinfra/command/01_base/file.rb
+++ b/mrblib/specinfra/command/01_base/file.rb
@@ -178,6 +178,7 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     def link_to(link, target, options = {})
       option = '-s'
       option << 'f' if options[:force]
+      option << 'n' if options[:no_dereference]
       "ln #{option} #{escape(target)} #{escape(link)}"
     end
 


### PR DESCRIPTION
Hi maintainers,

follow this change: https://github.com/mizzy/specinfra/pull/589 .
I am in trouble when using [mitamae](https://github.com/k0kubun/mitamae) because of nothing this change.