### PR TITLE
Support Debian 9

### DIFF
--- a/mrblib/specinfra/command/03_debian/base/port.rb
+++ b/mrblib/specinfra/command/03_debian/base/port.rb
@@ -1,2 +1,11 @@
 class Specinfra::Command::Debian::Base::Port < Specinfra::Command::Linux::Base::Port
+  class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 8
+        self
+      else
+        Specinfra::Command::Debian::V8::Port
+      end
+    end
+  end
 end

--- a/mrblib/specinfra/command/03_debian/base/service.rb
+++ b/mrblib/specinfra/command/03_debian/base/service.rb
@@ -1,5 +1,13 @@
 class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
+    def create(os_info=nil)
+      if (os_info || os)[:release].to_i < 8
+        self
+      else
+        Specinfra::Command::Debian::V8::Service
+      end
+    end
+
     def check_is_enabled(service, level=3)
       # Until everything uses Upstart, this needs an OR.
       "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}$' || grep '^\s*start on' /etc/init/#{escape(service)}.conf"

--- a/mrblib/specinfra/helper/detect_os/debian.rb
+++ b/mrblib/specinfra/helper/detect_os/debian.rb
@@ -3,22 +3,22 @@ module Specinfra
     class DetectOs
       class Debian < Specinfra::Helper::DetectOs
         def detect
-          if run_command('ls /etc/debian_version').success?
+          if (debian_version = run_command('cat /etc/debian_version')) && debian_version.success?
             distro  = nil
             release = nil
-            lsb_release = run_command("lsb_release -ir")
-            if lsb_release.success?
+            if (lsb_release = run_command("lsb_release -ir")) && lsb_release.success?
               lsb_release.stdout.each_line do |line|
                 distro  = line.split(':').last.strip if line =~ /^Distributor ID:/
                 release = line.split(':').last.strip if line =~ /^Release:/
               end
+            elsif (lsb_release = run_command("cat /etc/lsb-release")) && lsb_release.success?
+              lsb_release.stdout.each_line do |line|
+                distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
+                release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
+              end
             else
-              lsb_release = run_command("cat /etc/lsb-release")
-              if lsb_release.success?
-                lsb_release.stdout.each_line do |line|
-                  distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
-                  release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
-                end
+              if debian_version.stdout.chomp =~ /^[[:digit:]]+\.[[:digit:]]+$/
+                release = debian_version.stdout.chomp
               end
             end
             distro ||= 'debian'


### PR DESCRIPTION
- Detect debian version by /etc/debian_release
  - debian 9 does not have /etc/lsb_release.

https://github.com/mizzy/specinfra/pull/579

- Support debian9
  - use systemd as service resource

https://github.com/mizzy/specinfra/pull/633