### PR TITLE
[backport] Detect os name coreos correctly

### DIFF
--- a/mrblib/specinfra/helper/detect_os/coreos.rb
+++ b/mrblib/specinfra/helper/detect_os/coreos.rb
@@ -9,7 +9,7 @@ module Specinfra
             lsb_release = run_command("cat /etc/lsb-release")
             if lsb_release.success?
               lsb_release.stdout.each_line do |line|
-                distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
+                distro  = 'coreos' if line.include? 'CoreOS'
                 release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
               end
             end


### PR DESCRIPTION
# Context
I want to use mitamae on CoreOS, but error is occurred.

```
  [0] /home/mruby/code/mrblib/mitamae.rb:2
:in __main__
  [1] /home/mruby/code/mrblib/mitamae/cli.rb:4
:in start
  [2] /home/mruby/code/mrblib/mitamae/cli.rb:17
:in run
  [3] /home/mruby/code/mrblib/mitamae/cli/local.rb:37
:in run
  [4] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:8
:in execute
  [5] /home/mruby/code/mruby/mrblib/array.rb:18
:in each
  [6] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:9:in execute
  [7] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:19:in execute_node
  [8] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:31:in execute_children
  [9] /home/mruby/code/mrblib/mitamae/logger.rb:97:in with_indent
  [10] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:32:in execute_children
  [11] /home/mruby/code/mruby/mrblib/array.rb:18:in each
  [12] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:33:in execute_children
  [13] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:19:in execute_node
  [14] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:31:in execute_children
  [15] /home/mruby/code/mrblib/mitamae/logger.rb:97:in with_indent
  [16] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:32:in execute_children
  [17] /home/mruby/code/mruby/mrblib/array.rb:18:in each
  [18] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:33:in execute_children
  [19] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:24:in execute_node
  [20] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:13:in execute
  [21] /home/mruby/code/mrblib/mitamae/logger.rb:106:in with_indent_if
  [22] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:16:in execute
  [23] /home/mruby/code/mruby/mrblib/array.rb:18:in each
  [24] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:17:in execute
  [25] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:66:in run_action
  [26] /home/mruby/code/mrblib/mitamae/logger.rb:106:in with_indent_if
  [27] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:71:in run_action
  [28] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:130:in current_attributes
  [29] /home/mruby/code/mruby/mrbgems/mruby-object-ext/mrblib/object.rb:16:in tap
  [30] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:131:in current_attributes
  [31] /home/mruby/code/mrblib/mitamae/resource_executor/package.rb:23:in set_current_attributes
  [32] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:177:in run_specinfra
  [33] /home/mruby/code/mrblib/mitamae/runner.rb:19:in get_command
  [34] /home/mruby/code/mrblib/mitamae/backend.rb:48:in get_command
  [35] /home/mruby/code/mruby/build/mrbgems/mruby-specinfra/mrblib/specinfra/command_factory.rb:35:in get
  [36] /home/mruby/code/mruby/build/mrbgems/mruby-specinfra/mrblib/specinfra/ctory.rb:72:in version_class
  [37] /home/mruby/code/mruby/build/mrbgems/mruby-specinfra/mrblib/specinfra/command_factory.rb:83:in os_class
/home/mruby/code/mruby/build/mrbgems/mruby-specinfra/mrblib/specinfra/command_factory.rb:83: uninitialized constant Specinfra::Command::Containerlinuxbycoreos (NameError)
```

This patch is backport of https://github.com/mizzy/specinfra/pull/625