### PR TITLE
fix missleading test of ec2 metadata

### DIFF
--- a/test/specinfra.rb
+++ b/test/specinfra.rb
@@ -6,7 +6,7 @@ end
 assert('Specinfra host_inventory ec2') do
   backend = Specinfra::Backend::Exec.new(shell: '/bin/sh')
   assert_nil backend.host_inventory["ec2"]["instance-type"]
-  assert_nil backend.host_inventory[ec2][:"instance-type"]
+  assert_nil backend.host_inventory[:ec2][:"instance-type"]
 end
 
 assert('Specinfra get_command') do

--- a/test/specinfra.rb
+++ b/test/specinfra.rb
@@ -5,7 +5,8 @@ end
 
 assert('Specinfra host_inventory ec2') do
   backend = Specinfra::Backend::Exec.new(shell: '/bin/sh')
-  assert_nil backend.host_inventory[:ec2][:instance_type]
+  assert_nil backend.host_inventory["ec2"]["instance-type"]
+  assert_nil backend.host_inventory[ec2][:"instance-type"]
 end
 
 assert('Specinfra get_command') do


### PR DESCRIPTION
the key of instance type is `instance-type` not `instance_type`.

and there is degradation around ec2 metadata, https://github.com/itamae-kitchen/mruby-specinfra/commit/d802a755cfa94675c6df80547ca553abb323ec7f is lost.
https://github.com/mizzy/specinfra/pull/708 fixes it.