### PR TITLE
Update specinfra from v2.82.23 to v2.82.25

### DIFF
--- a/mrblib/specinfra/command/3_debian/base/port.rb
+++ b/mrblib/specinfra/command/3_debian/base/port.rb
@@ -1,10 +1,11 @@
 class Specinfra::Command::Debian::Base::Port < Specinfra::Command::Linux::Base::Port
   class << self
     def create(os_info=nil)
-      if (os_info || os)[:release].to_i < 8
-        self
-      else
+      release = (os_info || os)[:release]
+      if ["testing", "unstable"].include?(release) || release.to_i >= 8
         Specinfra::Command::Debian::V8::Port
+      else
+        self
       end
     end
   end

--- a/mrblib/specinfra/command/3_debian/base/service.rb
+++ b/mrblib/specinfra/command/3_debian/base/service.rb
@@ -1,10 +1,11 @@
 class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
     def create(os_info=nil)
-      if (os_info || os)[:release].to_i < 8
-        self
-      else
+      release = (os_info || os)[:release]
+      if ["testing", "unstable"].include?(release) || release.to_i >= 8
         Specinfra::Command::Debian::V8::Service
+      else
+        self
       end
     end
 

--- a/mrblib/specinfra/command/darwin/base/package.rb
+++ b/mrblib/specinfra/command/darwin/base/package.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Package
   class << self
     def check_is_installed(package, version=nil)
-      escaped_package = escape(File.basename(package))
+      escaped_package = escape(::File.basename(package))
       if version
         cmd = %Q[brew info #{escaped_package} | grep -E "^$(brew --prefix)/Cellar/#{escaped_package}/#{escape(version)}"]
       else
@@ -13,7 +13,7 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
     alias :check_is_installed_by_homebrew :check_is_installed
 
     def check_is_installed_by_homebrew_cask(package, version=nil)
-      escaped_package = escape(File.basename(package))
+      escaped_package = escape(::File.basename(package))
       if version
         cmd = "brew cask info #{escaped_package} | grep -E '^/opt/homebrew-cask/Caskroom/#{escaped_package}/#{escape(version)}'"
       else

--- a/mrblib/specinfra/version.rb
+++ b/mrblib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.82.23"
+  VERSION = "2.82.25"
 end

--- a/update_specinfra.rb
+++ b/update_specinfra.rb
@@ -5,7 +5,7 @@ require 'shellwords'
 require 'tmpdir'
 
 SPECINFRA_REPO    = 'mizzy/specinfra'
-SPECINFRA_VERSION = 'v2.82.23'
+SPECINFRA_VERSION = 'v2.82.25'
 
 module GitHubFetcher
   def self.fetch(repo, tag:, path:)


### PR DESCRIPTION
refs: https://github.com/mizzy/specinfra/pull/730

Update specinfra version to v.2.82.25 to resolve `undefined method 'basename' (NoMethodError)` error in package resource with darwin environment.