### PR TITLE
introduce GitHub Actions

### DIFF
--- a/.github/build_config.rb
+++ b/.github/build_config.rb
@@ -1,0 +1,6 @@
+MRuby::Build.new do |conf|
+  toolchain :gcc
+  conf.gembox 'default'
+  conf.gem '../../mruby-specinfra'
+  conf.enable_test
+end

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
           make -C mruby all
       - name: test
         run: |
-          make test
+          make -C mruby test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+      MRUBY_CONFIG: ${{ github.workspace }}/mruby-specinfra/.github/build_config.rb
+    steps:
+      - name: checkout mruby-specinfra
+        uses: actions/checkout@v2
+        with:
+          path: mruby-specinfra
+
+      # setup mruby
+      - name: checkout mruby
+        uses: actions/checkout@v2
+        with:
+          repository: 'mruby/mruby'
+          path: mruby
+
+      - name: build
+        run: |
+          make -C mruby all
+      - name: test
+        run: |
+          make test


### PR DESCRIPTION
Currently, the CI of mruby-specinfa is on travis-ci.org.
However, travis-ci.org shut down and it is now read-only mode.

> https://travis-ci.org/github/itamae-kitchen/mruby-specinfra
> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.
> Travis CI - Test and Deploy Your Code with Confidence is in read-only mode. The historical data can be downloaded to external file storage.

One of solutions is migrating to travis-ci.com (not .org), but I think that its plans are not OSS friendly.

https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

So, I propose that migrating to GitHub Actions.
It's free on public repositories, and easy to set up.

https://github.com/features/actions