### PR TITLE
Update Specinfra to 2.94.0

### DIFF
--- a/mrblib/specinfra/backend/1_exec.rb
+++ b/mrblib/specinfra/backend/1_exec.rb
@@ -146,7 +146,7 @@ module Specinfra
       end
 
       def with_env
-        keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
+        keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE BUNDLER_SETUP
             RUBYOPT GEM_HOME GEM_PATH GEM_CACHE]
 
         keys.each { |key| ENV["_SPECINFRA_#{key}"] = ENV[key] ; ENV.delete(key) }

--- a/mrblib/specinfra/helper/detect_os/debian.rb
+++ b/mrblib/specinfra/helper/detect_os/debian.rb
@@ -1,26 +1,52 @@
 class Specinfra::Helper::DetectOs::Debian < Specinfra::Helper::DetectOs
   def detect
     if (debian_version = run_command('cat /etc/debian_version')) && debian_version.success?
-      distro  = nil
-      release = nil
-      if (lsb_release = run_command("lsb_release -ir")) && lsb_release.success?
+      distro   = nil
+      release  = nil
+      codename = nil
+      if (lsb_release = run_command("lsb_release -irc")) && lsb_release.success?
         lsb_release.stdout.each_line do |line|
-          distro  = line.split(':').last.strip if line =~ /^Distributor ID:/
-          release = line.split(':').last.strip if line =~ /^Release:/
+          distro   = line.split(':').last.strip if line =~ /^Distributor ID:/
+          release  = line.split(':').last.strip if line =~ /^Release:/
+          codename = line.split(':').last.strip if line =~ /^Codename:/
         end
       elsif (lsb_release = run_command("cat /etc/lsb-release")) && lsb_release.success?
         lsb_release.stdout.each_line do |line|
-          distro  = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
-          release = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
+          distro   = line.split('=').last.strip if line =~ /^DISTRIB_ID=/
+          release  = line.split('=').last.strip if line =~ /^DISTRIB_RELEASE=/
+          codename = line.split('=').last.strip if line =~ /^DISTRIB_CODENAME=/
         end
-      else
-        if debian_version.stdout.chomp =~ /^[[:digit:]]+\.[[:digit:]]+$/
-          release = debian_version.stdout.chomp
+      elsif (lsb_release = run_command("cat /etc/os-release")) && lsb_release.success?
+        lsb_release.stdout.each_line do |line|
+          distro   = line.split('=').last.delete('"').strip if line =~ /^ID=/
+          release  = line.split('=').last.delete('"').strip if line =~ /^VERSION_ID=/
+          codename = line.split('=').last.delete('"').strip if line =~ /^VERSION_CODENAME=/
+        end
+        # There is no codename notation until Debian Jessie
+        if codename.nil?
+          lsb_release.stdout.each_line do |line|
+            version = line.split('=').last.delete('"').strip if line =~ /^VERSION=/
+            # For debian releases
+            if m = /^[0-9]+ \((\w+)\)$/.match(version)
+              codename = m[1]
+            end
+          end
         end
       end
       distro ||= 'debian'
-      release ||= nil
-      { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release }
+      # lsb-release not available or reported no version number:
+      if release.nil? || release == 'n/a'
+        release = case debian_version.stdout.chomp
+                  when /^[[:digit:]]+\.[[:digit:]]+$/
+                    debian_version.stdout.chomp
+                  when %r{^\w+/sid$}
+                    # a number larger than any normal Debian version ever:
+                    2**32 - 1.0
+                  else
+                    nil
+                  end
+      end
+      { :family => distro.gsub(/[^[:alnum:]]/, '').downcase, :release => release, :codename => codename }
     end
   end
 end

--- a/mrblib/specinfra/host_inventory.rb
+++ b/mrblib/specinfra/host_inventory.rb
@@ -7,6 +7,7 @@ module Specinfra
       domain
       fqdn
       platform
+      platform_codename
       platform_version
       filesystem
       cpu

--- a/mrblib/specinfra/host_inventory/platform_codename.rb
+++ b/mrblib/specinfra/host_inventory/platform_codename.rb
@@ -1,0 +1,9 @@
+module Specinfra
+  class HostInventory
+    class PlatformCodename < Base
+      def get
+        backend.os_info[:codename]
+      end
+    end
+  end
+end

--- a/mrblib/specinfra/version.rb
+++ b/mrblib/specinfra/version.rb
@@ -1,5 +1,5 @@
 module Specinfra
-  VERSION = "2.91.0"
+  VERSION = "2.94.0"
 
   def self.ruby_is_older_than?(*version)
     (RUBY_VERSION.split('.').map(&:to_i) <=> version) < 0

--- a/update_specinfra.rb
+++ b/update_specinfra.rb
@@ -8,7 +8,7 @@ require 'tmpdir'
 #   1. Update SPECINFRA_VERSION
 #   2. Run ./update_specinfra.rb
 SPECINFRA_REPO    = 'mizzy/specinfra'
-SPECINFRA_VERSION = 'v2.91.0'
+SPECINFRA_VERSION = 'v2.94.0'
 
 module GitHubFetcher
   def self.fetch(repo, tag:, path:)


### PR DESCRIPTION
update specinfra from v2.91.0 to v2.94.0.

[Changeset since Specinfra 2.91.0](https://github.com/mizzy/specinfra/compare/v2.91.0...v2.94.0)

This PR updates Specinfra fron 2.91.0 to 2.94.0.

The motivation for this change is the recently introduced support for the `platform_codename` host inventory.